### PR TITLE
Add Supabase client configuration via environment variables

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,8 @@
-# Supabase project configuration
+# Frontend Supabase client configuration
+VITE_SUPABASE_URL=""
+VITE_SUPABASE_ANON_KEY=""
+
+# Supabase project configuration (CLI / deployments)
 SUPABASE_ACCESS_TOKEN=""
 SUPABASE_PROJECT_REF=""
 SUPABASE_DB_PASSWORD=""

--- a/README.md
+++ b/README.md
@@ -47,15 +47,15 @@ npm --version
 
 ### npm-скрипты
 
-| Скрипт | Назначение |
-| ------ | ---------- |
-| `npm run dev` | Запуск Vite dev-сервера с hot module replacement. |
-| `npm run build` | Продакшен-сборка проекта. Минифицирует бандлы и использует purge Tailwind. |
-| `npm run preview` | Локальный предпросмотр собранной версии (`vite preview`). |
-| `npm run lint` | ESLint для `.vue`/`.ts` файлов (ошибки блокируют коммит и CI). |
-| `npm run format` | Автоформатирование с Prettier. |
-| `npm run test:type` | Проверка типов (`vue-tsc --noEmit`). |
-| `npm run prepare` | Установка git-хуков Husky. Запускается автоматически при `npm install`. |
+| Скрипт              | Назначение                                                                 |
+| ------------------- | -------------------------------------------------------------------------- |
+| `npm run dev`       | Запуск Vite dev-сервера с hot module replacement.                          |
+| `npm run build`     | Продакшен-сборка проекта. Минифицирует бандлы и использует purge Tailwind. |
+| `npm run preview`   | Локальный предпросмотр собранной версии (`vite preview`).                  |
+| `npm run lint`      | ESLint для `.vue`/`.ts` файлов (ошибки блокируют коммит и CI).             |
+| `npm run format`    | Автоформатирование с Prettier.                                             |
+| `npm run test:type` | Проверка типов (`vue-tsc --noEmit`).                                       |
+| `npm run prepare`   | Установка git-хуков Husky. Запускается автоматически при `npm install`.    |
 
 ### Качество и pre-commit
 
@@ -95,12 +95,12 @@ npm --version
 
 ### Типовые проблемы
 
-| Проблема | Решение |
-| -------- | ------- |
-| Конфликт порта `5173` при запуске dev-сервера | Запустите `npm run dev -- --port 5174` или укажите нужный порт в `.env`. |
-| Ошибки `npm install` после обновления зависимостей | Удалите `node_modules` и `package-lock.json`, повторно выполните `npm install`. |
-| Хуки Husky не срабатывают | Запустите `npm run prepare` и убедитесь, что выполняете команды из git-репозитория. |
-| Некорректная тема после очистки storage | Вызовите `localStorage.removeItem('color-scheme-preference')` или воспользуйтесь кнопкой "System" в `ThemeToggle`. |
+| Проблема                                           | Решение                                                                                                            |
+| -------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------ |
+| Конфликт порта `5173` при запуске dev-сервера      | Запустите `npm run dev -- --port 5174` или укажите нужный порт в `.env`.                                           |
+| Ошибки `npm install` после обновления зависимостей | Удалите `node_modules` и `package-lock.json`, повторно выполните `npm install`.                                    |
+| Хуки Husky не срабатывают                          | Запустите `npm run prepare` и убедитесь, что выполняете команды из git-репозитория.                                |
+| Некорректная тема после очистки storage            | Вызовите `localStorage.removeItem('color-scheme-preference')` или воспользуйтесь кнопкой "System" в `ThemeToggle`. |
 
 ### Наблюдаемость
 
@@ -112,6 +112,8 @@ npm --version
    ```bash
    cp .env.example .env
    ```
+
+   - `VITE_SUPABASE_URL` и `VITE_SUPABASE_ANON_KEY` соответствуют Project URL и anon key из Supabase Dashboard и используются фронтендом.
    - `SUPABASE_ACCESS_TOKEN` и `SUPABASE_PROJECT_REF` используются для деплоя.
    - `SUPABASE_DB_PASSWORD` потребуется при подключении к локальной базе.
 2. Запустите локальный стек Supabase:
@@ -136,7 +138,7 @@ make serve-webhook      # локальный запуск webhook-handler
 make deploy        # деплой двух функций в Supabase (требуются секреты)
 ```
 
-Edge-функции можно тестировать через Supabase CLI:
+Фронтенд инициализирует Supabase клиент через плагин `src/plugins/supabase.ts`, который читает значения `VITE_SUPABASE_URL` и `VITE_SUPABASE_ANON_KEY` из окружения. Edge-функции можно тестировать через Supabase CLI:
 
 ```bash
 supabase functions serve hello-world --env-file .env

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "vue-3-tailwind-starter",
       "version": "0.1.0",
       "dependencies": {
+        "@supabase/supabase-js": "^2.42.3",
         "pinia": "^2.1.7",
         "vue": "^3.4.21",
         "vue-i18n": "^9.9.0",
@@ -1500,6 +1501,80 @@
         "win32"
       ]
     },
+    "node_modules/@supabase/auth-js": {
+      "version": "2.71.1",
+      "resolved": "https://registry.npmjs.org/@supabase/auth-js/-/auth-js-2.71.1.tgz",
+      "integrity": "sha512-mMIQHBRc+SKpZFRB2qtupuzulaUhFYupNyxqDj5Jp/LyPvcWvjaJzZzObv6URtL/O6lPxkanASnotGtNpS3H2Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/node-fetch": "^2.6.14"
+      }
+    },
+    "node_modules/@supabase/functions-js": {
+      "version": "2.4.6",
+      "resolved": "https://registry.npmjs.org/@supabase/functions-js/-/functions-js-2.4.6.tgz",
+      "integrity": "sha512-bhjZ7rmxAibjgmzTmQBxJU6ZIBCCJTc3Uwgvdi4FewueUTAGO5hxZT1Sj6tiD+0dSXf9XI87BDdJrg12z8Uaew==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/node-fetch": "^2.6.14"
+      }
+    },
+    "node_modules/@supabase/node-fetch": {
+      "version": "2.6.15",
+      "resolved": "https://registry.npmjs.org/@supabase/node-fetch/-/node-fetch-2.6.15.tgz",
+      "integrity": "sha512-1ibVeYUacxWYi9i0cf5efil6adJ9WRyZBLivgjs+AUpewx1F3xPi7gLgaASI2SmIQxPoCEjAsLAzKPgMJVgOUQ==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      }
+    },
+    "node_modules/@supabase/postgrest-js": {
+      "version": "1.21.4",
+      "resolved": "https://registry.npmjs.org/@supabase/postgrest-js/-/postgrest-js-1.21.4.tgz",
+      "integrity": "sha512-TxZCIjxk6/dP9abAi89VQbWWMBbybpGWyvmIzTd79OeravM13OjR/YEYeyUOPcM1C3QyvXkvPZhUfItvmhY1IQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/node-fetch": "^2.6.14"
+      }
+    },
+    "node_modules/@supabase/realtime-js": {
+      "version": "2.15.5",
+      "resolved": "https://registry.npmjs.org/@supabase/realtime-js/-/realtime-js-2.15.5.tgz",
+      "integrity": "sha512-/Rs5Vqu9jejRD8ZeuaWXebdkH+J7V6VySbCZ/zQM93Ta5y3mAmocjioa/nzlB6qvFmyylUgKVS1KpE212t30OA==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/node-fetch": "^2.6.13",
+        "@types/phoenix": "^1.6.6",
+        "@types/ws": "^8.18.1",
+        "ws": "^8.18.2"
+      }
+    },
+    "node_modules/@supabase/storage-js": {
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/@supabase/storage-js/-/storage-js-2.12.1.tgz",
+      "integrity": "sha512-QWg3HV6Db2J81VQx0PqLq0JDBn4Q8B1FYn1kYcbla8+d5WDmTdwwMr+EJAxNOSs9W4mhKMv+EYCpCrTFlTj4VQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/node-fetch": "^2.6.14"
+      }
+    },
+    "node_modules/@supabase/supabase-js": {
+      "version": "2.57.4",
+      "resolved": "https://registry.npmjs.org/@supabase/supabase-js/-/supabase-js-2.57.4.tgz",
+      "integrity": "sha512-LcbTzFhHYdwfQ7TRPfol0z04rLEyHabpGYANME6wkQ/kLtKNmI+Vy+WEM8HxeOZAtByUFxoUTTLwhXmrh+CcVw==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/auth-js": "2.71.1",
+        "@supabase/functions-js": "2.4.6",
+        "@supabase/node-fetch": "2.6.15",
+        "@supabase/postgrest-js": "1.21.4",
+        "@supabase/realtime-js": "2.15.5",
+        "@supabase/storage-js": "2.12.1"
+      }
+    },
     "node_modules/@tailwindcss/forms": {
       "version": "0.5.10",
       "resolved": "https://registry.npmjs.org/@tailwindcss/forms/-/forms-0.5.10.tgz",
@@ -1544,11 +1619,16 @@
       "version": "20.19.17",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.17.tgz",
       "integrity": "sha512-gfehUI8N1z92kygssiuWvLiwcbOB3IRktR6hTDgJlXMYh5OvkPSRmgfoBUmfZt+vhwJtX7v1Yw4KvvAf7c5QKQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
       }
+    },
+    "node_modules/@types/phoenix": {
+      "version": "1.6.6",
+      "resolved": "https://registry.npmjs.org/@types/phoenix/-/phoenix-1.6.6.tgz",
+      "integrity": "sha512-PIzZZlEppgrpoT2QgbnDU+MMzuR6BbCjllj0bM70lWoejMeNJAxCchxnv7J3XFkI8MpygtRpzXrIlmWUBclP5A==",
+      "license": "MIT"
     },
     "node_modules/@types/semver": {
       "version": "7.7.1",
@@ -1556,6 +1636,15 @@
       "integrity": "sha512-FmgJfu+MOcQ370SD0ev7EI8TlCAfKYU+B4m5T3yXc1CiRN94g/SZPtsCkk506aUDtlMnFZvasDwHHUcZUEaYuA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "6.21.0",
@@ -5228,6 +5317,12 @@
         "node": ">=8.0"
       }
     },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "license": "MIT"
+    },
     "node_modules/ts-api-utils": {
       "version": "1.4.3",
       "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-1.4.3.tgz",
@@ -5292,7 +5387,6 @@
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/update-browserslist-db": {
@@ -5534,6 +5628,22 @@
         "typescript": ">=5.0.0"
       }
     },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -5677,6 +5787,27 @@
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/ws": {
+      "version": "8.18.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
+      "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
     },
     "node_modules/xml-name-validator": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     ]
   },
   "dependencies": {
+    "@supabase/supabase-js": "^2.42.3",
     "pinia": "^2.1.7",
     "vue": "^3.4.21",
     "vue-i18n": "^9.9.0",

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -1,1 +1,10 @@
 /// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+  readonly VITE_SUPABASE_URL: string
+  readonly VITE_SUPABASE_ANON_KEY: string
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -4,6 +4,7 @@ import { createPinia } from 'pinia'
 import App from './App.vue'
 import router from './router'
 import i18n, { initializeI18nLocale } from './plugins/i18n'
+import { installSupabase } from './plugins/supabase'
 import { initializeColorScheme } from './composables/useColorScheme'
 
 import './assets/main.scss'
@@ -16,5 +17,7 @@ const app = createApp(App)
 app.use(createPinia())
 app.use(router)
 app.use(i18n)
+
+installSupabase(app)
 
 app.mount('#app')

--- a/src/plugins/supabase.ts
+++ b/src/plugins/supabase.ts
@@ -1,0 +1,31 @@
+import { createClient, type SupabaseClient } from '@supabase/supabase-js'
+import { inject, type App, type InjectionKey } from 'vue'
+
+const supabaseUrl = import.meta.env.VITE_SUPABASE_URL
+if (!supabaseUrl) {
+  throw new Error('VITE_SUPABASE_URL environment variable is not defined')
+}
+
+const supabaseAnonKey = import.meta.env.VITE_SUPABASE_ANON_KEY
+if (!supabaseAnonKey) {
+  throw new Error('VITE_SUPABASE_ANON_KEY environment variable is not defined')
+}
+
+const client = createClient(supabaseUrl, supabaseAnonKey)
+
+export const supabaseClientKey: InjectionKey<SupabaseClient> = Symbol('SupabaseClient')
+
+export const installSupabase = (app: App): void => {
+  app.provide(supabaseClientKey, client)
+}
+
+export const useSupabaseClient = (): SupabaseClient => {
+  const instance = inject(supabaseClientKey)
+  if (!instance) {
+    throw new Error('Supabase client is not provided. Did you call installSupabase()?')
+  }
+
+  return instance
+}
+
+export const supabaseClient = client


### PR DESCRIPTION
## Summary
- add a Supabase client plugin that reads the project URL and anon key from environment variables and provides it to Vue
- expose the VITE_SUPABASE_URL and VITE_SUPABASE_ANON_KEY variables in .env.example and document them in the README
- add the @supabase/supabase-js dependency and declare the new Vite env typings

## Testing
- npm run lint
- npm run test:type
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cecef553ec833087c73dd1be47aba0